### PR TITLE
RA balance changes September 2019

### DIFF
--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -8,7 +8,7 @@ BADR:
 	Aircraft:
 		CruiseAltitude: 2560
 		TurnSpeed: 5
-		Speed: 149
+		Speed: 180
 		Repulsable: False
 		MaximumPitch: 56
 	Cargo:
@@ -47,11 +47,11 @@ BADR.Bomber:
 	Aircraft:
 		CruiseAltitude: 2560
 		TurnSpeed: 5
-		Speed: 149
+		Speed: 180
 		Repulsable: False
 		MaximumPitch: 56
 	AmmoPool:
-		Ammo: 7
+		Ammo: 5
 	-Selectable:
 	SelectionDecorations:
 		RenderSelectionBars: False
@@ -111,6 +111,7 @@ MIG:
 	AttackAircraft:
 		FacingTolerance: 20
 		PersistentTargeting: false
+		AttackTurnDelay: 30
 	Aircraft:
 		CruiseAltitude: 2560
 		InitialFacing: 192

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -68,7 +68,7 @@ V2RL:
 	Armor:
 		Type: Heavy
 	Mobile:
-		Speed: 128
+		Speed: 118
 	RevealsShroud:
 		Range: 5c0
 		RevealGeneratedShroud: False

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -45,9 +45,9 @@
 
 Maverick:
 	Inherits: ^AntiGroundMissile
-	ReloadDelay: 30
+	ReloadDelay: 50
 	Range: 9c0
-	MinRange: 3c0
+	MinRange: 2c0
 	Report: missile7.aud
 	Burst: 2
 	BurstDelays: 7

--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -73,7 +73,7 @@ Napalm:
 
 ^TeslaWeapon:
 	ReloadDelay: 3
-	Range: 8c512
+	Range: 8c0
 	Report: tesla1.aud
 	Projectile: TeslaZap
 	Warhead@1Dam: SpreadDamage

--- a/mods/ra/weapons/smallcaliber.yaml
+++ b/mods/ra/weapons/smallcaliber.yaml
@@ -262,6 +262,9 @@ M60mg:
 	Range: 4c0
 	Report: pillbox1.aud
 	Burst: 5
+	Warhead@1Dam: SpreadDamage
+		Versus:
+			Light: 30
 
 ^SnipeWeapon:
 	ReloadDelay: 80

--- a/mods/ra/weapons/superweapons.yaml
+++ b/mods/ra/weapons/superweapons.yaml
@@ -1,5 +1,5 @@
 ParaBomb:
-	ReloadDelay: 10
+	ReloadDelay: 8
 	Range: 3c0
 	Report: chute1.aud
 	Projectile: GravityBomb


### PR DESCRIPTION
### Ranger  
- Anti-light damage from 40% to 30%
   - It makes Mobile Flaks better counter ranger. Now a full health Flak will always win 2v1s and will have a better chance at winning 5v2 (Flak is always the smaller number here)
### Light Tank 
- Speed from 128 to 118
   - This change was proposed earlier along with Mobile Flak speed nerf but due to Light Tank underperforming at the time it was rejected / delayed. Speed will now be the same as Mobile Flak and will again allow Mobile Flak openers in SvA

Opportunity fire was a great addition to OpenRA, but nothing comes without cons. It caused more balance issues then we have expected and we have another example on our hands. About a month ago a new light vehicle meta started to emerge. A build was found that let's you build 5 rangers, 1 Ranger and 3 Light Tanks, something in between or 4 mobile Flaks and it let's your MCV out at a standard double refinery build timing. Currently it favours Allies, in a SvA matchup Soviets have to fully give up map control until heavy tanks roll out in order not to waste assets. Changes proposed above are there to help Soviets fight for map control
### Tesla Coil
- Reduce Range from 8.5 to 8
   - Teslas will no longer fire on ghost structures. It makes teslas fall more inline with other anti-ground defences as all of them have the same or less weapon range than vision. Another solution was to increase their vision instead but due to popular opinion that Soviet base push is too strong this one was chosen
### Badger 
- Speed from 149 to 180
   - Direction of Parabombs in the playtest can now be selected but as a counter-nerf bomb fall speed was drastically decreased. This lead to people feeling underwhelmed as Parabombs can no longer wipe out armies as they used to. Despite that, Parabombs remain to be one of the strongest if not the strongest sub-faction traits. Though considering that Badgers are planes they move at a turtles pace. It was previously necessary as mentioned above, Parabombs could wipe out armies with little to no time to react. Now they will be given a speed of yaks. It will make Parabombs more effective farther from the edges and sound effects will feel more impactful as there will be a delay between dropping bombs and them exploding
- DropInterval to 5 (property in ParaDrop)
- ParaBomb ReloadDelay from 10 to 8
   - Adjustments to account for the speed increase
- Reduced ammo from 7 to 5 
   - Badgers only drop 5 bombs each so having 7 ammo is redundant 
### Mig
- Minimum range from 3 to 2
- AttackTurnDelay to 30
- ReloadDelay from 30 to 50
   - It will be easier to handle Migs 